### PR TITLE
This downgrades SQLAlchemy to a previous stable release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=19.3.1
 pytest>=5.4.1
 
-sqlalchemy>=1.3.12
+sqlalchemy==1.3.12
 SQLAlchemy-Utils==0.36.3 # 0.36.8 breaks database_exists() call
 
 flask-sqlalchemy>=2.4.1


### PR DESCRIPTION
This is a quick fix, but if we keep this in the bug list, we can allocate time to fix the code to work with the latter version of SQLAlchemy.