### PR TITLE
make the CROP 2.0 link in the sidebar point back to homepage

### DIFF
--- a/webapp/app/base/templates/site_template/sidebar.html
+++ b/webapp/app/base/templates/site_template/sidebar.html
@@ -1,6 +1,6 @@
 <div class="left_col scroll-view">
   <div class="navbar nav_title" style="border: 0;">
-    <a href="" class="site_title"> <span>CROP 2.0</span></a>
+    <a href="/home/index" class="site_title"> <span>CROP 2.0</span></a>
   </div>
 
   <div class="clearfix"></div>


### PR DESCRIPTION
Personally (let me know if you disagree!) I think it would be intuitive for the "CROP 2.0" at the top left of the website, to always link to the homepage ("/home/index").   Currently the link is "", which just points to whatever the current page is.
This one-line PR makes it a link to "/home/index".