### PR TITLE
Fix Zensie dashboard for new sensors

### DIFF
--- a/webapp/app/dashboards/routes.py
+++ b/webapp/app/dashboards/routes.py
@@ -51,6 +51,8 @@ SENSOR_CATEORIES = {
     25: "R&D",
     26: "Fridge",
     27: "MidFarm",
+    48: "Propagation",
+    49: "R&D",
 }
 
 # Ventilation constants
@@ -409,7 +411,14 @@ def temperature_range_analysis(temp_df, dt_from, dt_to):
         # estimating hourly temperature mean values
         sensor_grp_temp = sensor_grp["temperature"].mean().reset_index()
 
-        bins = TEMP_BINS[SENSOR_CATEORIES[sensor_id]]
+        try:
+            bins = TEMP_BINS[SENSOR_CATEORIES[sensor_id]]
+        except KeyError:
+            logging.error(
+                f"Don't know how to categorise or bin sensor {sensor_id} "
+                "in the Zensie dashboard."
+            )
+            continue
         # binning temperature values
         sensor_grp_temp["temp_bin"] = pd.cut(sensor_grp_temp["temperature"], bins)
 

--- a/webapp/app/dashboards/templates/zensie_dashboard.html
+++ b/webapp/app/dashboards/templates/zensie_dashboard.html
@@ -48,17 +48,19 @@
 
           <!--
           Sensor IDs:
-          21: 1B1
+          21: 1B2
           18: 16B1
           27: 16B2
           23: 16B4
-          22: 29B1
-          20: Tunnel 5
-          19: Propagation
-          24: R&H 1
-          25: R&H 2
+          22: 29B2
+          20: Propagation #1
+          19: Tunnel 7
+          24: R&D 1
+          25: R&D 2
+          48: Propagation #2
+          49: R&D 4
           --!>
-          {% for row_group in [[21], [18, 27, 23], [22], [20], [19], [24, 25]] %}
+          {% for row_group in [[21], [18, 27, 23], [22], [19], [20, 48], [24, 25, 49]] %}
           <div class="row">
             {% for id in row_group %}
             <div class="col-lg-4 col-md-6 col-sm-12">


### PR DESCRIPTION
Add a couple of new sensors to the hard coded lists of sensors, and make it such that in the future adding new sensors won't break the page.

Still needs the _actual_ fix, which would be to read all the location data from the database rather than from the hard coded `dict`.