### PR TITLE
Zone fix

### DIFF
--- a/webapp/app/base/static/javascript/home.js
+++ b/webapp/app/base/static/javascript/home.js
@@ -5,38 +5,43 @@ function check_data(data) {
 }
 
 function set_hourly_values(hourly_data_json) {
+  data_FF = hourly_data_json.find((s) => s["region"] == "FrontFarm");
+  data_FM = hourly_data_json.find((s) => s["region"] == "MidFarm");
+  data_FB = hourly_data_json.find((s) => s["region"] == "BackFarm");
+  data_PR = hourly_data_json.find((s) => s["region"] == "Propagation");
+  data_RD = hourly_data_json.find((s) => s["region"] == "R&D");
   const numDecimals = 1;
-  let tempFF = hourly_data_json[1]["temperature"].toFixed(numDecimals);
+  let tempFF = data_FF["temperature"].toFixed(numDecimals);
   document.getElementById("tempFF").innerHTML = tempFF;
-  let tempFM = hourly_data_json[2]["temperature"].toFixed(numDecimals);
+  let tempFM = data_FM["temperature"].toFixed(numDecimals);
   document.getElementById("tempFM").innerHTML = tempFM;
-  let tempFB = hourly_data_json[0]["temperature"].toFixed(numDecimals);
+  let tempFB = data_FB["temperature"].toFixed(numDecimals);
   document.getElementById("tempFB").innerHTML = tempFB;
-  let tempPR = hourly_data_json[3]["temperature"].toFixed(numDecimals);
+  let tempPR = data_PR["temperature"].toFixed(numDecimals);
   document.getElementById("tempPR").innerHTML = tempPR;
-  let tempRD = hourly_data_json[4]["temperature"].toFixed(numDecimals);
+  let tempRD = data_RD["temperature"].toFixed(numDecimals);
   document.getElementById("tempRD").innerHTML = tempRD;
 
-  let humFF = hourly_data_json[1]["humidity"].toFixed(numDecimals);
+  let humFF = data_FF["humidity"].toFixed(numDecimals);
   document.getElementById("humFF").innerHTML = humFF;
-  let humFM = hourly_data_json[2]["humidity"].toFixed(numDecimals);
+  let humFM = data_FM["humidity"].toFixed(numDecimals);
   document.getElementById("humFM").innerHTML = humFM;
-  let humFB = hourly_data_json[0]["humidity"].toFixed(numDecimals);
+  let humFB = data_FB["humidity"].toFixed(numDecimals);
   document.getElementById("humFB").innerHTML = humFB;
-  let humPR = hourly_data_json[3]["humidity"].toFixed(numDecimals);
+  let humPR = data_PR["humidity"].toFixed(numDecimals);
   document.getElementById("humPR").innerHTML = humPR;
-  let humRD = hourly_data_json[4]["humidity"].toFixed(numDecimals);
+  let humRD = data_RD["humidity"].toFixed(numDecimals);
   document.getElementById("humRD").innerHTML = humRD;
 
-  let vpdFF = hourly_data_json[1]["vpd"].toFixed(numDecimals);
+  let vpdFF = data_FF["vpd"].toFixed(numDecimals);
   document.getElementById("vpdFF").innerHTML = vpdFF;
-  let vpdFM = hourly_data_json[2]["vpd"].toFixed(numDecimals);
+  let vpdFM = data_FM["vpd"].toFixed(numDecimals);
   document.getElementById("vpdFM").innerHTML = vpdFM;
-  let vpdFB = hourly_data_json[0]["vpd"].toFixed(numDecimals);
+  let vpdFB = data_FB["vpd"].toFixed(numDecimals);
   document.getElementById("vpdFB").innerHTML = vpdFB;
-  let vpdPR = hourly_data_json[3]["vpd"].toFixed(numDecimals);
+  let vpdPR = data_PR["vpd"].toFixed(numDecimals);
   document.getElementById("vpdPR").innerHTML = vpdPR;
-  let vpdRD = hourly_data_json[4]["vpd"].toFixed(numDecimals);
+  let vpdRD = data_RD["vpd"].toFixed(numDecimals);
   document.getElementById("vpdRD").innerHTML = vpdRD;
 }
 
@@ -102,17 +107,17 @@ function time_series_charts(
   return new Chart(ctx, config);
 }
 
-function roundcharts(json_data, zoneid, canvasname, colouramp) {
+function roundcharts(json_data, regionid, canvasname, colouramp) {
   bin_ = [];
   cnt_ = [];
-  for (j = 0; j < json_data[zoneid]["Values"].length; j++) {
-    bin_.push(json_data[zoneid]["Values"][j]["bin"]);
-    cnt_.push(parseFloat(json_data[zoneid]["Values"][j]["cnt"]));
+  for (j = 0; j < json_data[regionid]["Values"].length; j++) {
+    bin_.push(json_data[regionid]["Values"][j]["bin"]);
+    cnt_.push(parseFloat(json_data[regionid]["Values"][j]["cnt"]));
   }
 
   const data_ = [];
   data_.push({
-    label: [json_data[zoneid]["zone"]],
+    label: [json_data[regionid]["region"]],
     data: cnt_,
     backgroundColor: colouramp,
   });
@@ -138,13 +143,13 @@ function roundcharts(json_data, zoneid, canvasname, colouramp) {
   new Chart(ctx, config);
 }
 
-function horizontal_charts(json_data, zoneid, canvasname, colouramp) {
-  // iterates through zones (5)
+function horizontal_charts(json_data, regionid, canvasname, colouramp) {
+  // iterates through regions (5)
   bin_ = [];
   cnt_ = [];
-  for (j = 0; j < json_data[zoneid]["Values"].length; j++) {
-    bin_.push(json_data[zoneid]["Values"][j]["bin"]);
-    cnt_.push(parseFloat(json_data[zoneid]["Values"][j]["cnt"]));
+  for (j = 0; j < json_data[regionid]["Values"].length; j++) {
+    bin_.push(json_data[regionid]["Values"][j]["bin"]);
+    cnt_.push(parseFloat(json_data[regionid]["Values"][j]["cnt"]));
   }
 
   const datasets_ = [];
@@ -157,7 +162,7 @@ function horizontal_charts(json_data, zoneid, canvasname, colouramp) {
   }
 
   const data = {
-    labels: [json_data[zoneid]["zone"]],
+    labels: [json_data[regionid]["region"]],
     datasets: datasets_,
   };
 
@@ -243,16 +248,16 @@ function create_charts(
   ];
 
   // main farm
-  let zone0_name = temperature_data[0]["zone"];
-  document.getElementById("zone0_name").innerHTML = zone0_name;
+  let region0_name = temperature_data[0]["region"];
+  document.getElementById("region0_name").innerHTML = region0_name;
   roundcharts(temperature_data, 0, "roundchart0", colouramp_redbluegrey);
 
-  let zone1_name = temperature_data[1]["zone"];
-  document.getElementById("zone1_name").innerHTML = zone1_name;
+  let region1_name = temperature_data[1]["region"];
+  document.getElementById("region1_name").innerHTML = region1_name;
   roundcharts(temperature_data, 1, "roundchart1", colouramp_redbluegrey);
 
-  let zone2_name = temperature_data[2]["zone"];
-  document.getElementById("zone2_name").innerHTML = zone2_name;
+  let region2_name = temperature_data[2]["region"];
+  document.getElementById("region2_name").innerHTML = region2_name;
   roundcharts(temperature_data, 2, "roundchart2", colouramp_redbluegrey);
 
   roundcharts(temperature_data_daily, 0, "roundchart10", colouramp_redbluegrey);
@@ -353,8 +358,8 @@ function create_charts(
   ]);
 
   // Propagation
-  let zone3_name = temperature_data[3]["zone"];
-  document.getElementById("zone3_name").innerHTML = zone3_name;
+  let region3_name = temperature_data[3]["region"];
+  document.getElementById("region3_name").innerHTML = region3_name;
   roundcharts(temperature_data, 3, "roundchart3", colouramp_redbluegrey);
   roundcharts(temperature_data_daily, 3, "roundchart13", colouramp_redbluegrey);
 
@@ -365,8 +370,8 @@ function create_charts(
   roundcharts(vpd_data_daily, 3, "vpd_roundchart13", colouramp_bluegrey);
 
   // R&D
-  let zone4_name = temperature_data[4]["zone"];
-  document.getElementById("zone4_name").innerHTML = zone4_name;
+  let region4_name = temperature_data[4]["region"];
+  document.getElementById("region4_name").innerHTML = region4_name;
   roundcharts(temperature_data, 4, "roundchart4", colouramp_redbluegrey);
   roundcharts(temperature_data_daily, 4, "roundchart14", colouramp_redbluegrey);
 

--- a/webapp/app/home/routes.py
+++ b/webapp/app/home/routes.py
@@ -50,6 +50,9 @@ VPD_BINS = {
     "R&D": [0.0, 300.0, 600.0, 1000.0, 1500.0],
 }
 LOCATION_REGIONS = ["Propagation", "FrontFarm", "MidFarm", "BackFarm", "R&D"]
+# The last columns considered to be in FrontFarm and MidFarm, respectively.
+REGION_SPLIT_FRONT_MID = 10
+REGION_SPLIT_MID_BACK = 20
 
 
 def resample(df_, bins):
@@ -81,6 +84,10 @@ def resample(df_, bins):
 
 
 def farm_region(zone, aisle, column, shelf):
+    """Given the exact location of a sensor, return what we call the "region", which
+    distinguishes between front, back, and mid parts of a tunnel (propagation and R&D
+    are regions by themselves).
+    """
     if zone in ("R&D", "Propagation"):
         return zone
     # TODO Update the next line.
@@ -93,11 +100,11 @@ def farm_region(zone, aisle, column, shelf):
         "BackFarm",
     ) or aisle not in ("A", "B"):
         return "N/A"
-    if column < 10:
+    if column <= REGION_SPLIT_FRONT_MID:
         return "FrontFarm"
-    if column > 20:
-        return "BackFarm"
-    return "MidFarm"
+    if column <= REGION_SPLIT_MID_BACK:
+        return "MidFarm"
+    return "BackFarm"
 
 
 def aranet_query(dt_from, dt_to):

--- a/webapp/app/home/routes.py
+++ b/webapp/app/home/routes.py
@@ -85,20 +85,12 @@ def resample(df_, bins):
 
 def farm_region(zone, aisle, column, shelf):
     """Given the exact location of a sensor, return what we call the "region", which
-    distinguishes between front, back, and mid parts of a tunnel (propagation and R&D
-    are regions by themselves).
+    distinguishes between front, back, and mid parts of tunnel 3. Propagation and R&D
+    are regions by themselves, other tunnels have region "N/A".
     """
     if zone in ("R&D", "Propagation"):
         return zone
-    # TODO Update the next line.
-    if zone not in (
-        "Farm",
-        "Farm1",
-        "FF",
-        "MidFarm",
-        "FrontFarm",
-        "BackFarm",
-    ) or aisle not in ("A", "B"):
+    if zone != "Tunnel3":
         return "N/A"
     if column <= REGION_SPLIT_FRONT_MID:
         return "FrontFarm"

--- a/webapp/app/home/routes.py
+++ b/webapp/app/home/routes.py
@@ -14,10 +14,11 @@ from app.home import blueprint
 
 from __app__.crop.structure import SQLA as db
 from __app__.crop.structure import (
-    SensorClass,
     LocationClass,
-    SensorLocationClass,
     ReadingsAranetTRHClass,
+    SensorClass,
+    SensorLocationClass,
+    TypeClass,
 )
 from __app__.crop.constants import CONST_TIMESTAMP_FORMAT
 from utilities.utils import filter_latest_sensor_location, vapour_pressure_deficit
@@ -48,7 +49,7 @@ VPD_BINS = {
     "BackFarm": [0.0, 300.0, 600.0, 1000.0, 1500.0],
     "R&D": [0.0, 300.0, 600.0, 1000.0, 1500.0],
 }
-LOCATION_ZONES = ["Propagation", "FrontFarm", "MidFarm", "BackFarm", "R&D"]
+LOCATION_REGIONS = ["Propagation", "FrontFarm", "MidFarm", "BackFarm", "R&D"]
 
 
 def resample(df_, bins):
@@ -79,6 +80,26 @@ def resample(df_, bins):
     return df_out
 
 
+def farm_region(zone, aisle, column, shelf):
+    if zone in ("R&D", "Propagation"):
+        return zone
+    # TODO Update the next line.
+    if zone not in (
+        "Farm",
+        "Farm1",
+        "FF",
+        "MidFarm",
+        "FrontFarm",
+        "BackFarm",
+    ) or aisle not in ("A", "B"):
+        return "N/A"
+    if column < 10:
+        return "FrontFarm"
+    if column > 20:
+        return "BackFarm"
+    return "MidFarm"
+
+
 def aranet_query(dt_from, dt_to):
     """
     Performs a query for Aranet T/RH sensors.
@@ -103,15 +124,12 @@ def aranet_query(dt_from, dt_to):
         ReadingsAranetTRHClass.sensor_id,
         ReadingsAranetTRHClass.temperature,
         ReadingsAranetTRHClass.humidity,
-        LocationClass.zone,
+        SensorClass.id,
     ).filter(
         and_(
-            SensorLocationClass.location_id == LocationClass.id,
             ReadingsAranetTRHClass.sensor_id == SensorClass.id,
-            ReadingsAranetTRHClass.sensor_id == SensorLocationClass.sensor_id,
             ReadingsAranetTRHClass.timestamp >= dt_from,
             ReadingsAranetTRHClass.timestamp <= dt_to,
-            filter_latest_sensor_location(db),
         )
     )
 
@@ -120,13 +138,41 @@ def aranet_query(dt_from, dt_to):
         df.loc[:, "temperature"], df.loc[:, "humidity"]
     )
 
+    query = db.session.query(
+        SensorClass.id,
+        LocationClass.zone,
+        LocationClass.aisle,
+        LocationClass.column,
+        LocationClass.shelf,
+    ).filter(
+        and_(
+            TypeClass.sensor_type == "Aranet T&RH",
+            SensorClass.type_id == TypeClass.id,
+            SensorClass.id == SensorLocationClass.sensor_id,
+            SensorLocationClass.location_id == LocationClass.id,
+            filter_latest_sensor_location(db),
+        )
+    )
+    df_location = pd.read_sql(query.statement, query.session.bind).set_index("id")
+    df_location.loc[:, "region"] = df_location.apply(
+        lambda row: farm_region(row["zone"], row["aisle"], row["column"], row["shelf"]),
+        axis=1,
+    )
+    # TODO I think the following is essentially a join.
+    for sensor_id in df["id"].unique():
+        try:
+            region = df_location.loc[sensor_id, "region"]
+        except KeyError:
+            region = "Unknown"
+        df.loc[df["id"] == sensor_id, "region"] = region
+
     logging.info("Total number of records found: %d" % (len(df.index)))
     if df.empty:
         logging.debug("WARNING: Query returned empty")
     return df
 
 
-def grp_per_hr_zone(temp_df):
+def grp_per_hr_region(temp_df):
     """
     finds mean of values per hour for a selected date.
     Returns a dataframe ready for json
@@ -136,16 +182,10 @@ def grp_per_hr_zone(temp_df):
         dt_from: date range from
         dt_to: date range to
     Returns:
-        df_grp_zone_hr: df with temperate ranges
+        df_grp_region_hr: df with temperate ranges
     """
 
     df = copy.deepcopy(temp_df)
-
-    # df["timestamp"] = pd.to_datetime(df["timestamp"])
-
-    # mask per selected date
-    # mask = (df["timestamp"] >= dt_from) & (df["timestamp"] <= dt_to)
-    # filtered_df = df.loc[mask]
 
     # extracting date from datetime
     df["date"] = pd.to_datetime(df["timestamp"].dt.date)
@@ -153,13 +193,13 @@ def grp_per_hr_zone(temp_df):
     # Reseting index
     df.sort_values(by=["timestamp"], ascending=True).reset_index(inplace=True)
 
-    df_grp_zone_hr = (
+    df_grp_region_hr = (
         df.groupby(
             by=[
                 df.timestamp.map(
                     lambda x: "%04d-%02d-%02d-%02d" % (x.year, x.month, x.day, x.hour)
                 ),
-                "zone",
+                "region",
                 "date",
             ]
         )
@@ -167,7 +207,7 @@ def grp_per_hr_zone(temp_df):
         .reset_index()
     )
 
-    return df_grp_zone_hr
+    return df_grp_region_hr
 
 
 def stratification(temp_df, sensor_ids):
@@ -207,7 +247,7 @@ def stratification(temp_df, sensor_ids):
 def bin_trh_data(df, bins, measure, expected_total=None):
     """
     Return a dataframe with counts of how many measurements of `measure` were in each of
-    the bins, by zone.
+    the bins, by region.
 
     Arguments:
         df: data
@@ -218,33 +258,33 @@ def bin_trh_data(df, bins, measure, expected_total=None):
         output: A merged df with counts per bin
     """
     output_list = []
-    for zone in LOCATION_ZONES:
-        # check if zone exists in current bins dictionary:
-        if zone not in bins:
-            logging.info("WARNING: %s doesn't exist in current bin dictionary" % zone)
+    for region in LOCATION_REGIONS:
+        # check if region exists in current bins dictionary:
+        if region not in bins:
+            logging.info("WARNING: %s doesn't exist in current bin dictionary" % region)
             continue
 
-        df_each_zone = df.loc[df.zone == zone, :].copy()
+        df_each_region = df.loc[df.region == region, :].copy()
         # breaks df in
-        df_each_zone["bin"] = pd.cut(df_each_zone[measure], bins[zone])
+        df_each_region["bin"] = pd.cut(df_each_region[measure], bins[region])
         # converting bins to str
-        df_each_zone["bin"] = df_each_zone["bin"].astype(str)
+        df_each_region["bin"] = df_each_region["bin"].astype(str)
         # groups df per each bin
-        bin_grp = df_each_zone.groupby(by=["zone", "bin"])
+        bin_grp = df_each_region.groupby(by=["region", "bin"])
         # get measure counts per bin
         bin_cnt = bin_grp[measure].count().reset_index()
         # renames column with counts
         bin_cnt.rename(columns={measure: "cnt"}, inplace=True)
-        df_ = resample(bin_cnt, bins[zone])
+        df_ = resample(bin_cnt, bins[region])
         if expected_total:
             total = df_["cnt"].sum()
             df_.loc[df.index.max() + 1] = [
-                zone,
+                region,
                 "missing",
                 expected_total - total,
             ]
-        # renames the values of all the zones
-        df_["zone"] = zone
+        # renames the values of all the regions
+        df_["region"] = region
         output_list.append(df_)
 
     # Merge all df in one.
@@ -258,7 +298,7 @@ def json_bin_counts(df):
     dashboard.
     """
     output = (
-        df.groupby(["zone"], as_index=True)
+        df.groupby(["region"], as_index=True)
         .apply(lambda x: x[["bin", "cnt"]].to_dict(orient="records"))
         .reset_index()
         .rename(columns={0: "Values"})
@@ -274,7 +314,7 @@ def json_hum(df_hum):
 
     """
     return (
-        df_hum.groupby(["zone"], as_index=True)
+        df_hum.groupby(["region"], as_index=True)
         .apply(lambda x: x[["bin", "cnt"]].to_dict("r"))
         .reset_index()
         .rename(columns={0: "Values"})
@@ -282,18 +322,26 @@ def json_hum(df_hum):
     )
 
 
-def current_values_json(df_hourly):
+def regional_mean_json(df_hourly):
+    """Compute a DataFrame with the per-region means of the inputs T&RH columns."""
+    df_mean = (
+        df_hourly.loc[
+            :,
+            # df_hourly.groupby("region").timestamp.max(),
+            ["temperature", "humidity", "vpd", "timestamp", "region"],
+        ]
+        .groupby("region")
+        .mean()
+    ).reset_index()
 
-    df_test = df_hourly.loc[df_hourly.groupby("zone").timestamp.idxmax()]
-    df_test["temperature"] = df_test["temperature"].astype(int)
+    for i in range(len(LOCATION_REGIONS)):
 
-    for i in range(len(LOCATION_ZONES)):
+        if not df_mean["region"].str.contains(LOCATION_REGIONS[i]).any():
+            df2 = pd.DataFrame({"region": [LOCATION_REGIONS[i]]})
+            df_mean = df_mean.append(df2)
 
-        if not df_test["zone"].str.contains(LOCATION_ZONES[i]).any():
-            df2 = pd.DataFrame({"zone": [LOCATION_ZONES[i]]})
-            df_test = df_test.append(df2)
-
-    return df_test.to_json(orient="records")
+    return_value = df_mean.to_json(orient="records")
+    return return_value
 
 
 @blueprint.route("/index")
@@ -311,7 +359,7 @@ def index():
     # weekly
     df_weekly = aranet_query(dt_from_weekly, dt_to)
     if not df_weekly.empty:
-        df_mean_hr_weekly = grp_per_hr_zone(df_weekly)
+        df_mean_hr_weekly = grp_per_hr_region(df_weekly)
         df_temp_weekly = bin_trh_data(
             df_mean_hr_weekly, TEMP_BINS, "temperature", expected_total=24 * 7
         )
@@ -324,15 +372,13 @@ def index():
         weekly_temp_json = json_bin_counts(df_temp_weekly)
         weekly_hum_json = json_bin_counts(df_hum_weekly)
         weekly_vpd_json = json_bin_counts(df_vpd_weekly)
-        # Sensor id locations:
-        # 18: 16B1, 21: 1B2, 22: 29B2, 23: 16B4
     else:
         weekly_temp_json = {}
         weekly_hum_json = {}
 
     df_daily = aranet_query(dt_from_daily, dt_to)
     if not df_daily.empty:
-        df_mean_hr_daily = grp_per_hr_zone(df_daily)
+        df_mean_hr_daily = grp_per_hr_region(df_daily)
         df_temp_daily = bin_trh_data(
             df_mean_hr_daily, TEMP_BINS, "temperature", expected_total=24
         )
@@ -352,12 +398,14 @@ def index():
 
     df_hourly = aranet_query(dt_from_hourly, dt_to)
     if not df_hourly.empty:
-        hourly_json = current_values_json(df_hourly)
+        hourly_json = regional_mean_json(df_hourly)
     else:
         hourly_json = {}
 
     df_fortnightly = aranet_query(dt_from_fortnightly, dt_to)
     if not df_fortnightly.empty:
+        # Sensor id locations:
+        # 18: 16B1, 21: 1B2, 22: 29B2, 23: 16B4
         json_strat = stratification(df_fortnightly, (18, 21, 22, 23))
     else:
         json_strat = {}

--- a/webapp/app/home/templates/index.html
+++ b/webapp/app/home/templates/index.html
@@ -80,23 +80,23 @@
               <div class="block_content">
 
                 <table style="table-layout: fixed;width:100%; overflow:visible">
-                  <!-- TODO Why is the order of the zones in the columns so confusingly
-                    zone1, zone2, zone0, zone3, zone4?
+                  <!-- TODO Why is the order of the regions in the columns so confusingly
+                    region1, region2, region0, region3, region4?
                   -->
                   <tr>
                     <th bgcolor="#e7e7e7">Main farm</th>
                     <th bgcolor="#f3f3f3">Main farm</th>
                     <th bgcolor="#e7e7e7">Main farm</th>
-                    <th bgcolor="#f3f3f3"><span id="zone3_name"></span></th>
-                    <th bgcolor="#e7e7e7"><span id="zone4_name"></span></th>
+                    <th bgcolor="#f3f3f3"><span id="region3_name"></span></th>
+                    <th bgcolor="#e7e7e7"><span id="region4_name"></span></th>
                   </tr>
                 </table>
 
                 <table style="table-layout: fixed;width:100%; overflow:visible">
                   <tr>
-                    <th bgcolor="#e7e7e7"><span id="zone1_name" ></span></th>
-                    <th bgcolor="#f3f3f3"><span id="zone2_name"></span></th>
-                    <th bgcolor="#e7e7e7"><span id="zone0_name" ></span></th>
+                    <th bgcolor="#e7e7e7"><span id="region1_name" ></span></th>
+                    <th bgcolor="#f3f3f3"><span id="region2_name"></span></th>
+                    <th bgcolor="#e7e7e7"><span id="region0_name" ></span></th>
                     <th bgcolor="#f3f3f3"></th>
                     <th bgcolor="#e7e7e7"></th>
                   </tr>
@@ -124,7 +124,7 @@
                       <p style="font-weight:normal">daily</p>
                     </th>
                     <th width=25% bgcolor="#f3f3f3">
-                      <span id="zone2_name"></span>
+                      <span id="region2_name"></span>
                       <canvas id="roundchart2" ></canvas>
                       <p style="font-weight:normal">weekly</p>
                     </th>
@@ -133,7 +133,7 @@
                       <p style="font-weight:normal">daily</p>
                     </th>
                     <th width=25% bgcolor="#e7e7e7">
-                      <span id="zone0_name"></span>
+                      <span id="region0_name"></span>
                       <canvas id="roundchart0" ></canvas>
                       <p style="font-weight:normal">weekly</p>
                     </th>


### PR DESCRIPTION
This PR adjusts the code for the home page to not rely on hard coded zones like `FrontFarm` and `MidFarm`. Rather it assumes a new location naming scheme, where zones are the different tunnels, and separates the front/mid/back parts (which I call "regions", to distinguish from zones) by column.

In implementing this I found a few small bugs in the old code for handling the current readings shown on the home page. Those are now
* rounded correctly,
* actually averages from the last hour of all the sensors in that region, rather than picking a random recent reading from one of them,
* is more robust, because the javascript code no longer relies on the arbitrary order in which python returns a certain array.

To work, this PR had to be coupled with running the following SQL transaction on the DB. The same needs to be run on prod when merging dev -> main. Before doing that, we should doublecheck that the hardcoded row IDs in the SQL transaction are correct for the prod DB too.

```BEGIN;
-- Set the nullability of location columns as we want them.
ALTER TABLE locations ALTER COLUMN zone SET NOT NULL;
ALTER TABLE locations ALTER COLUMN aisle DROP NOT NULL;
ALTER TABLE locations ALTER COLUMN shelf DROP NOT NULL;
ALTER TABLE locations ALTER COLUMN "column" DROP NOT NULL;
-- Locations 1 and 16 are identical, except one has zone FF the other Farm.
-- Remove one of them.
UPDATE sensor_location SET location_id = 1 WHERE location_id = 16;
DELETE FROM locations WHERE id = 16;
-- Fix the one special case where aisle is set to be 1. We assume this means aisle A.
UPDATE locations SET aisle = 'A' WHERE aisle = '1';
-- Fix the zones, based on aisle.
UPDATE locations SET zone = 'Tunnel3' WHERE aisle='A' and (zone = 'Farm1' or zone = 'Farm' or zone = 'FF' or zone = 'FrontFarm' or zone = 'MidFarm' or zone = 'BackFarm');
UPDATE locations SET zone = 'Tunnel3' WHERE aisle='B' and (zone = 'Farm1' or zone = 'Farm' or zone = 'FF' or zone = 'FrontFarm' or zone = 'MidFarm' or zone = 'BackFarm');
UPDATE locations SET zone = 'Tunnel4' WHERE aisle='E' and (zone = 'Farm1' or zone = 'Farm' or zone = 'FF' or zone = 'FrontFarm' or zone = 'MidFarm' or zone = 'BackFarm');
UPDATE locations SET zone = 'Tunnel5' WHERE aisle='C' and (zone = 'Farm1' or zone = 'Farm' or zone = 'FF' or zone = 'FrontFarm' or zone = 'MidFarm' or zone = 'BackFarm');
UPDATE locations SET zone = 'Tunnel6' WHERE aisle='D' and (zone = 'Farm1' or zone = 'Farm' or zone = 'FF' or zone = 'FrontFarm' or zone = 'MidFarm' or zone = 'BackFarm');
-- Various propagation and R&D locations become identical once the bogus aisle/column/shelf info is removed.
-- Merge them into a single location.
UPDATE sensor_location SET location_id = 17 WHERE location_id = 18;
DELETE FROM locations WHERE id = 18;
UPDATE sensor_location SET location_id = 28 WHERE location_id = 29;
DELETE FROM locations WHERE id = 29;
UPDATE sensor_location SET location_id = 28 WHERE location_id = 40;
DELETE FROM locations WHERE id = 40;
-- Set aisle/column/shelf to null for locations outside the main farm.
UPDATE locations SET "column" = NULL WHERE (zone = 'Propagation' or zone = 'R&D' or zone = 'Retired' or zone = 'Not in use' or zone = 'Lobby1' or zone = 'Unknown');
UPDATE locations SET aisle = NULL WHERE (zone = 'Propagation' or zone = 'R&D' or zone = 'Retired' or zone = 'Not in use' or zone = 'Lobby1' or zone = 'Unknown');
UPDATE locations SET shelf = NULL WHERE (zone = 'Propagation' or zone = 'R&D' or zone = 'Retired' or zone = 'Not in use' or zone = 'Lobby1' or zone = 'Unknown');
COMMIT;
```

See the resulting locations table here: http://cropapptest.azurewebsites.net/locations/locations

Implements most of https://github.com/alan-turing-institute/CROP/issues/244