### PR TITLE
Fix import iterable error

### DIFF
--- a/webapp/app/dashboards/routes.py
+++ b/webapp/app/dashboards/routes.py
@@ -2,7 +2,10 @@
 Analysis dashboards module.
 """
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import copy
 from datetime import datetime, timedelta
 import json


### PR DESCRIPTION
Realized that when running `webapp/run.sh` with Python 3.10 installed you get the import error: **cannot import name 'Iterable' from 'collections'** . 
Apparently the `Iterable` abstract class was removed from `collections` in Python 3.10.
It should be imported from `collections.abc` instead.
Fixed this in `webapp/app/dashboards/routes.py` so that by default it imports from `collections.abc`, unless you get an import error in which case it imports from `collections`.