### PR TITLE
Display crop information

### DIFF
--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -32,16 +32,17 @@ def register_extensions(app):
 def register_blueprints(app):
     module_list = (
         "base",
+        "crops",
         "dashboards",
         "home",
         "locations",
         "logs",
+        "predictions",
         "queries",
         "readings",
         "sensors",
         "types",
         "users",
-        "predictions",
     )
 
     for module_name in module_list:

--- a/webapp/app/base/static/css/custom.css
+++ b/webapp/app/base/static/css/custom.css
@@ -4002,3 +4002,16 @@ ul.notifications {
     background-color: #ffff !important;
 }
 /** /bootstrap-datetimepicker **/
+
+.text-alignright {
+  text-align: right;
+}
+
+.table-borderless > tbody > tr > td,
+.table-borderless > tbody > tr > th,
+.table-borderless > tfoot > tr > td,
+.table-borderless > tfoot > tr > th,
+.table-borderless > thead > tr > td,
+.table-borderless > thead > tr > th {
+    border: none
+}

--- a/webapp/app/base/static/javascript/batch_details.js
+++ b/webapp/app/base/static/javascript/batch_details.js
@@ -1,0 +1,50 @@
+const plotConfigTemplate = {
+  type: "line",
+  options: {
+    responsive: true,
+    plugins: {
+      legend: false,
+    },
+    scales: {
+      y: {
+        display: true,
+        title: {
+          display: true,
+          font: { size: 18 },
+        },
+      },
+      x: {
+        type: "time",
+        time: {
+          displayFormats: {
+            hour: "DD MMM hA",
+          },
+        },
+        ticks: {
+          maxTicksLimit: 6,
+          includeBounds: false,
+        },
+      },
+    },
+  },
+};
+
+function makePlots(data, yDataName, canvasName, yLabel, colour) {
+  const datasets = [];
+  const pointRadius = 1;
+  const borderWidth = 1;
+  datasets.push({
+    data: data.map((row) => {
+      return { x: row["timestamp"], y: row[yDataName] };
+    }),
+    pointRadius: pointRadius,
+    borderWidth: borderWidth,
+    borderColor: colour,
+    fill: true,
+  });
+  const config = JSON.parse(JSON.stringify(plotConfigTemplate)); // Make a copy
+  config.options.scales.y.title.text = yLabel;
+  config.data = { datasets: datasets };
+  const ctx = document.getElementById(canvasName);
+  new Chart(ctx, config);
+}

--- a/webapp/app/base/templates/site_template/sidebar.html
+++ b/webapp/app/base/templates/site_template/sidebar.html
@@ -25,14 +25,14 @@
       <h3>General</h3>
       <ul class="nav side-menu">
 
-        <li><a><i class="fa fa-map-marker"></i> Views <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa-home"></i> Views <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
             <li><a href="/home/index">Home</a></li>
             <li><a href="/home/model">3D Model</a></li>
           </ul>
         </li>
 
-        <li><a><i class="fa fa fa-laptop"></i> Dashboards <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa fa-bar-chart"></i> Dashboards <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
             <li><a href="/dashboards/aranet_trh_dashboard">Aranet T&RH</a></li>
             <li><a href="/dashboards/energy_dashboard">Energy</a></li>
@@ -40,17 +40,25 @@
           </ul>
         </li>
 
-        <li><a><i class="fa fa fa-laptop"></i> Predictions <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa fa-line-chart"></i> Predictions <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
             <li><a href="/predictions/arima">Arima Model</a></li>
             <li><a href="/predictions/ges">GES Model</a></li>
           </ul>
         </li>
 
-        <li><a><i class="fa fa-flag-o"></i> Locations <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa-leaf"></i> Crops <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
-            <li><a href="/locations/locations">List of Locations</a></li>
-            <li><a href="/locations/location_form">New Location</a></li>
+            <li><a href="/crops/batch_list">Batches</a></li>
+          </ul>
+        </li>
+
+        <li><a><i class="fa fa-table"></i> Readings <span class="fa fa-chevron-down"></span></a>
+          <ul class="nav child_menu">
+            <li><a href="/readings/aranet_trh">Aranet T&RH</a></li>
+            <li><a href="/readings/aranet_co2">Aranet CO2</a></li>
+            <li><a href="/readings/aranet_air_velocity">Aranet Air Velocity</a></li>
+            <li><a href="/readings/energy">Energy</a></li>
           </ul>
         </li>
 
@@ -62,12 +70,10 @@
           </ul>
         </li>
 
-        <li><a><i class="fa fa-table"></i> Readings <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa-flag-o"></i> Locations <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
-            <li><a href="/readings/aranet_trh">Aranet T&RH</a></li>
-            <li><a href="/readings/aranet_co2">Aranet CO2</a></li>
-            <li><a href="/readings/aranet_air_velocity">Aranet Air Velocity</a></li>
-            <li><a href="/readings/energy">Energy</a></li>
+            <li><a href="/locations/locations">List of Locations</a></li>
+            <li><a href="/locations/location_form">New Location</a></li>
           </ul>
         </li>
 

--- a/webapp/app/crops/__init__.py
+++ b/webapp/app/crops/__init__.py
@@ -1,0 +1,9 @@
+from flask import Blueprint
+
+blueprint = Blueprint(
+    "crops_blueprint",
+    __name__,
+    url_prefix="/crops",
+    template_folder="templates",
+    static_folder="static",
+)

--- a/webapp/app/crops/routes.py
+++ b/webapp/app/crops/routes.py
@@ -26,7 +26,7 @@ from core.structure import (
 )
 
 
-@blueprint.route("/batch_list", methods=["GET"])
+@blueprint.route("/batch_list", methods=["GET", "POST"])
 @login_required
 def batch_list():
     """Render the batch_list page.
@@ -160,9 +160,12 @@ def batch_list():
         df[column] = pd.to_datetime(df[column]).dt.strftime("%Y-%m-%d %H:%M")
     results_arr = df.to_dict("records")
 
-    return render_template(
-        "batch_list.html",
-        batches=results_arr,
-        dt_from=dt_from.strftime("%B %d, %Y"),
-        dt_to=dt_to.strftime("%B %d, %Y"),
-    )
+    if request.method == "POST":
+        return download_csv(results_arr, "batch_list")
+    else:
+        return render_template(
+            "batch_list.html",
+            batches=results_arr,
+            dt_from=dt_from.strftime("%B %d, %Y"),
+            dt_to=dt_to.strftime("%B %d, %Y"),
+        )

--- a/webapp/app/crops/routes.py
+++ b/webapp/app/crops/routes.py
@@ -1,0 +1,157 @@
+"""
+Module for sensor data.
+"""
+
+from flask import render_template, request
+from flask_login import login_required
+from sqlalchemy import and_, desc
+import pandas as pd
+import io
+
+from app.crops import blueprint
+from core.utils import (
+    query_result_to_array,
+    parse_date_range_argument,
+    download_csv,
+)
+
+from core.structure import SQLA as db
+from core.structure import (
+    BatchClass,
+    BatchEventClass,
+    CropTypeClass,
+    EventType,
+    LocationClass,
+    HarvestClass,
+)
+
+
+@blueprint.route("/batch_list", methods=["GET"])
+@login_required
+def batch_list():
+    dt_from, dt_to = parse_date_range_argument(request.args.get("range"))
+
+    query = (
+        db.session.query(
+            BatchClass.id.label("batch_id"),
+            BatchClass.tray_size,
+            BatchClass.number_of_trays,
+            BatchClass.crop_type_id.label("batch_crop_type_id"),
+            CropTypeClass.id.label("crop_type_id"),
+            CropTypeClass.name.label("crop_type_name"),
+            BatchEventClass.id.label("batch_event_id"),
+            BatchEventClass.batch_id.label("event_batch_id"),
+            BatchEventClass.location_id.label("event_location_id"),
+            BatchEventClass.event_type,
+            BatchEventClass.event_time,
+            BatchEventClass.next_action_time,
+            HarvestClass.batch_event_id.label("harvest_batch_event_id"),
+            HarvestClass.crop_yield,
+            HarvestClass.waste_disease,
+            HarvestClass.waste_defect,
+            HarvestClass.over_production,
+            LocationClass.id.label("location_id"),
+            LocationClass.zone,
+            LocationClass.aisle,
+            LocationClass.column,
+            LocationClass.shelf,
+        )
+        .join(CropTypeClass, CropTypeClass.id == BatchClass.crop_type_id)
+        .outerjoin(BatchEventClass, BatchEventClass.batch_id == BatchClass.id)
+        .outerjoin(HarvestClass, HarvestClass.batch_event_id == BatchEventClass.id)
+        .outerjoin(LocationClass, LocationClass.id == BatchEventClass.location_id)
+    )
+    df_raw = pd.read_sql(query.statement, query.session.bind)
+
+    # Group events by batch, and manually collect the relevant information from each
+    # event type, if available. Build a new dataframe with only the information we want,
+    # constructing each row as a dictionary first. TODO Might there be a way to lift
+    # some of this work over to the Postgres server? Could be faster.
+    grouped = df_raw.groupby("batch_id")
+    rows = []
+    for batch_id, group in grouped:
+        row = {"batch_id": batch_id}
+        row_weigh = group[group["event_type"] == EventType.weigh]
+        row_propagate = group[group["event_type"] == EventType.propagate]
+        row_transfer = group[group["event_type"] == EventType.transfer]
+        row_harvest = group[group["event_type"] == EventType.harvest]
+
+        if len(row_weigh) > 0:
+            # Usually there should only be one event of each type per batch, so just
+            # pick the first one.
+            row_weigh = row_weigh.iloc[0]
+            row = {
+                "tray_size": row_weigh["tray_size"],
+                "number_of_trays": row_weigh["number_of_trays"],
+                "crop_type_id": row_weigh["crop_type_id"],
+                "crop_type_name": row_weigh["crop_type_name"],
+                "weigh_time": row_weigh["event_time"],
+                **row,
+            }
+            row["last_event"] = "weigh"
+
+        if len(row_propagate) > 0:
+            row_propagate = row_propagate.iloc[0]
+            row = {"propagate_time": row_propagate["event_time"], **row}
+            row["last_event"] = "propagate"
+
+        if len(row_transfer) > 0:
+            row_transfer = row_transfer.iloc[0]
+            row = {
+                "location_id": row_transfer["location_id"],
+                "zone": row_transfer["zone"],
+                "aisle": row_transfer["aisle"],
+                "shelf": row_transfer["shelf"],
+                "transfer_time": row_transfer["event_time"],
+                **row,
+            }
+            row["last_event"] = "transfer"
+
+        if len(row_harvest) > 0:
+            row_harvest = row_harvest.iloc[0]
+            row = {
+                "crop_yield": row_harvest["crop_yield"],
+                "waste_disease": row_harvest["waste_disease"],
+                "waste_defect": row_harvest["waste_defect"],
+                "over_production": row_harvest["over_production"],
+                "harvest_time": row_harvest["event_time"],
+                **row,
+            }
+            row["last_event"] = "harvest"
+
+        rows.append(row)
+
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "batch_id",
+            "last_event",
+            "crop_type_id",
+            "crop_type_name",
+            "tray_size",
+            "number_of_trays",
+            "weigh_time",
+            "propagate_time",
+            "transfer_time",
+            "harvest_time",
+            "location_id",
+            "zone",
+            "aisle",
+            "shelf",
+            "crop_yield",
+            "waste_disease",
+            "waste_defect",
+            "over_production",
+        ],
+    )
+    # Format the time strings. Easier to do here than in the Jinja template.
+    for column in ["weigh_time", "propagate_time", "transfer_time", "harvest_time"]:
+        df[column] = df[column].dt.strftime("%Y-%m-%d %H:%M")
+    results_arr = df.to_dict("records")
+
+    return render_template(
+        "batch_list.html",
+        batches=results_arr,
+        dt_from=dt_from.strftime("%B %d, %Y"),
+        dt_to=dt_to.strftime("%B %d, %Y"),
+    )

--- a/webapp/app/crops/routes.py
+++ b/webapp/app/crops/routes.py
@@ -10,9 +10,10 @@ import io
 
 from app.crops import blueprint
 from core.utils import (
-    query_result_to_array,
-    parse_date_range_argument,
     download_csv,
+    parse_date_range_argument,
+    query_result_to_array,
+    vapour_pressure_deficit,
 )
 
 from core.structure import SQLA as db
@@ -23,7 +24,62 @@ from core.structure import (
     EventType,
     LocationClass,
     HarvestClass,
+    ReadingsAranetTRHClass,
 )
+
+
+def collect_batch_details(df_batch):
+    """Given a DataFrame that has rows for a given batch only, one per event, construct
+    a dictionary of the attributes we care about, discarding others.
+    """
+    details = {}
+    row_weigh = df_batch[df_batch["event_type"] == EventType.weigh]
+    row_propagate = df_batch[df_batch["event_type"] == EventType.propagate]
+    row_transfer = df_batch[df_batch["event_type"] == EventType.transfer]
+    row_harvest = df_batch[df_batch["event_type"] == EventType.harvest]
+
+    if len(row_weigh) > 0:
+        # Usually there should only be one event of each type per batch, so just
+        # pick the first one.
+        row_weigh = row_weigh.iloc[0]
+        details["tray_size"] = row_weigh["tray_size"]
+        details["number_of_trays"] = row_weigh["number_of_trays"]
+        details["crop_type_id"] = row_weigh["crop_type_id"]
+        details["crop_type_name"] = row_weigh["crop_type_name"]
+        details["weigh_time"] = row_weigh["event_time"]
+        details["last_event"] = "weigh"
+        # At this point we have enough data to at least have some kind of row in the
+        # table. The following parts modify `row` in-place.
+    else:
+        # If we don't have the weighing event for this batch, we don't want to
+        # process any of the others either. This is to avoid confusing cases where
+        # e.g. the harvest event was in the time range provided but the weighing
+        # wasn't and thus there would be a row with data missing.
+        return details
+
+    if len(row_propagate) > 0:
+        row_propagate = row_propagate.iloc[0]
+        details["propagate_time"] = row_propagate["event_time"]
+        details["last_event"] = "propagate"
+
+    if len(row_transfer) > 0:
+        row_transfer = row_transfer.iloc[0]
+        details["location_id"] = row_transfer["location_id"]
+        details["zone"] = row_transfer["zone"]
+        details["aisle"] = row_transfer["aisle"]
+        details["shelf"] = row_transfer["shelf"]
+        details["transfer_time"] = row_transfer["event_time"]
+        details["last_event"] = "transfer"
+
+    if len(row_harvest) > 0:
+        row_harvest = row_harvest.iloc[0]
+        details["crop_yield"] = row_harvest["crop_yield"]
+        details["waste_disease"] = row_harvest["waste_disease"]
+        details["waste_defect"] = row_harvest["waste_defect"]
+        details["over_production"] = row_harvest["over_production"]
+        details["harvest_time"] = row_harvest["event_time"]
+        details["last_event"] = "harvest"
+    return details
 
 
 @blueprint.route("/batch_list", methods=["GET", "POST"])
@@ -83,54 +139,9 @@ def batch_list():
     grouped = df_raw.groupby("batch_id")
     rows = []
     for batch_id, group in grouped:
-        row = {"batch_id": batch_id}
-        row_weigh = group[group["event_type"] == EventType.weigh]
-        row_propagate = group[group["event_type"] == EventType.propagate]
-        row_transfer = group[group["event_type"] == EventType.transfer]
-        row_harvest = group[group["event_type"] == EventType.harvest]
-
-        if len(row_weigh) > 0:
-            # Usually there should only be one event of each type per batch, so just
-            # pick the first one.
-            row_weigh = row_weigh.iloc[0]
-            row["tray_size"] = row_weigh["tray_size"]
-            row["number_of_trays"] = row_weigh["number_of_trays"]
-            row["crop_type_id"] = row_weigh["crop_type_id"]
-            row["crop_type_name"] = row_weigh["crop_type_name"]
-            row["weigh_time"] = row_weigh["event_time"]
-            row["last_event"] = "weigh"
-            # At this point we have enough data to at least have some kind of row in the
-            # table. The following parts modify `row` in-place.
-            rows.append(row)
-        else:
-            # If we don't have the weighing event for this batch, we don't want to
-            # process any of the others either. This is to avoid confusing cases where
-            # e.g. the harvest event was in the time range provided but the weighing
-            # wasn't and thus there would be a row with data missing.
-            continue
-
-        if len(row_propagate) > 0:
-            row_propagate = row_propagate.iloc[0]
-            row["propagate_time"] = row_propagate["event_time"]
-            row["last_event"] = "propagate"
-
-        if len(row_transfer) > 0:
-            row_transfer = row_transfer.iloc[0]
-            row["location_id"] = row_transfer["location_id"]
-            row["zone"] = row_transfer["zone"]
-            row["aisle"] = row_transfer["aisle"]
-            row["shelf"] = row_transfer["shelf"]
-            row["transfer_time"] = row_transfer["event_time"]
-            row["last_event"] = "transfer"
-
-        if len(row_harvest) > 0:
-            row_harvest = row_harvest.iloc[0]
-            row["crop_yield"] = row_harvest["crop_yield"]
-            row["waste_disease"] = row_harvest["waste_disease"]
-            row["waste_defect"] = row_harvest["waste_defect"]
-            row["over_production"] = row_harvest["over_production"]
-            row["harvest_time"] = row_harvest["event_time"]
-            row["last_event"] = "harvest"
+        details = collect_batch_details(group)
+        details["batch_id"] = batch_id
+        rows.append(details)
 
     df = pd.DataFrame(
         rows,
@@ -169,3 +180,103 @@ def batch_list():
             dt_from=dt_from.strftime("%B %d, %Y"),
             dt_to=dt_to.strftime("%B %d, %Y"),
         )
+
+
+def find_closest_sensor(zone, aisle, column, shelf):
+    """Return the sensor ID of the sensor closest to this location."""
+    # TODO Move this to utils?
+    # TODO Implement this. Currently just returning a constant to test the rest of the
+    # pipeline.
+    return 19
+
+
+def query_trh_data(sensor_id, dt_from, dt_to):
+    query = db.session.query(
+        ReadingsAranetTRHClass.timestamp,
+        ReadingsAranetTRHClass.sensor_id,
+        ReadingsAranetTRHClass.temperature,
+        ReadingsAranetTRHClass.humidity,
+    ).filter(
+        and_(
+            ReadingsAranetTRHClass.sensor_id == sensor_id,
+            ReadingsAranetTRHClass.timestamp >= dt_from,
+            ReadingsAranetTRHClass.timestamp <= dt_to,
+        )
+    )
+
+    df = pd.read_sql(query.statement, query.session.bind)
+    df.loc[:, "vpd"] = vapour_pressure_deficit(
+        df.loc[:, "temperature"], df.loc[:, "humidity"]
+    )
+    return df
+
+
+@blueprint.route("/batch_details", methods=["GET"])
+@login_required
+def batch_details():
+    """Render the details of a batch."""
+    batch_id = int(request.args.get("id"))
+    query = (
+        db.session.query(
+            BatchClass.id.label("batch_id"),
+            BatchClass.tray_size,
+            BatchClass.number_of_trays,
+            BatchClass.crop_type_id.label("batch_crop_type_id"),
+            CropTypeClass.id.label("crop_type_id"),
+            CropTypeClass.name.label("crop_type_name"),
+            BatchEventClass.id.label("batch_event_id"),
+            BatchEventClass.batch_id.label("event_batch_id"),
+            BatchEventClass.location_id.label("event_location_id"),
+            BatchEventClass.event_type,
+            BatchEventClass.event_time,
+            BatchEventClass.next_action_time,
+            HarvestClass.batch_event_id.label("harvest_batch_event_id"),
+            HarvestClass.crop_yield,
+            HarvestClass.waste_disease,
+            HarvestClass.waste_defect,
+            HarvestClass.over_production,
+            LocationClass.id.label("location_id"),
+            LocationClass.zone,
+            LocationClass.aisle,
+            LocationClass.column,
+            LocationClass.shelf,
+        )
+        .join(CropTypeClass, CropTypeClass.id == BatchClass.crop_type_id)
+        .outerjoin(BatchEventClass, BatchEventClass.batch_id == BatchClass.id)
+        .outerjoin(HarvestClass, HarvestClass.batch_event_id == BatchEventClass.id)
+        .outerjoin(LocationClass, LocationClass.id == BatchEventClass.location_id)
+        .filter(BatchClass.id == batch_id)
+    )
+    df_raw = pd.read_sql(query.statement, query.session.bind)
+    details = collect_batch_details(df_raw)
+    details["grow_time"] = details["harvest_time"] - details["transfer_time"]
+    details["yield_per_tray"] = details["yield"] / details["number_of_trays"]
+
+    dt_from = details["transfer_time"]
+    dt_to = details["harvest_time"]
+    if dt_from and dt_to:
+        sensor_id = find_closest_sensor(
+            details["zone"], details["aisle"], details["column"], details["shelf"]
+        )
+        trh_df = query_trh_data(sensor_id, dt_from, dt_to)
+        trh_data = trh_df.to_dict("records")
+        trh_summary = {
+            "mean_temperature": pd.mean(trh_df.loc[:, "temperature"]),
+            "mean_humidity": pd.mean(trh_df.loc[:, "humidity"]),
+            "mean_vpd": pd.mean(trh_df.loc[:, "vpd"]),
+        }
+    else:
+        trh_data = {}
+        trh_summary = {
+            "mean_temperature": None,
+            "mean_humidity": None,
+            "mean_vpd": None,
+        }
+
+    # Format the time strings. Easier to do here than in the Jinja template.
+    for column in ["weigh_time", "propagate_time", "transfer_time", "harvest_time"]:
+        details[column] = pd.to_datetime(details[column]).dt.strftime("%Y-%m-%d %H:%M")
+
+    return render_template(
+        "batch_details.html", details=details, trh=trh_data, trh_summary=trh_summary
+    )

--- a/webapp/app/crops/templates/batch_details.html
+++ b/webapp/app/crops/templates/batch_details.html
@@ -79,6 +79,22 @@
                     <td>{{ details.over_production }}</td>
                   </tr>
                   <tr>
+                    <td class="text-alignright">Closest sensor</td>
+                    {% if not trh_summary|length == 0 %}
+                    <td>{{ trh_summary.sensor_name }}</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Sensor location</td>
+                    {% if not trh_summary|length == 0 %}
+                    <td>{{ trh_summary.sensor_location }}</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                  <tr>
                     <td class="text-alignright">Mean temperature</td>
                     {% if not trh_summary|length == 0 %}
                     <td>{{ '%0.1f'|format(trh_summary.mean_temperature|float) }}°C</td>

--- a/webapp/app/crops/templates/batch_details.html
+++ b/webapp/app/crops/templates/batch_details.html
@@ -1,0 +1,141 @@
+{% extends "base_site.html" %}
+
+{% block title %} CROP BATCH DETAILS {% endblock title %}
+
+{% block content %}
+<div class="right_col" role="main">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 col-sm-12 col-xs-12">
+        <div class="x_panel">
+          <div class="x_content">
+            <h3>Batch details</h3>
+
+            <div class="col-md-3 col-sm-4 col-xs-6">
+              <table class="table table-borderless">
+                <tbody>
+                  <tr>
+                    <td class="text-alignright">Batch ID</td>
+                    <td>{{ details.batch_id }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Last event</td>
+                    <td>{{ details.last_event }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Crop type</td>
+                    <td>{{ details.crop_type_name }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Tray size</td>
+                    <td>{{ details.tray_size }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Trays</td>
+                    <td>{{ details.number_of_trays }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Weigh time</td>
+                    <td>{{ details.weigh_time }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Propagate time</td>
+                    <td>{{ details.propagate_time }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Transfer time</td>
+                    <td>{{ details.transfer_time }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Harvest time</td>
+                    <td>{{ details.harvest_time }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Grow time</td>
+                    <td>{{ details.grow_time }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Location</td>
+                    <td>{{ details.location }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Yield</td>
+                    <td>{{ details.crop_yield }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Yield per tray</td>
+                    <td>{{ details.yield_per_tray }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Disease</td>
+                    <td>{{ details.waste_disease }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Defect</td>
+                    <td>{{ details.waste_defect }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Over-production</td>
+                    <td>{{ details.over_production }}</td>
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Mean temperature</td>
+                    {% if not trh_summary|length == 0 %}
+                    <td>{{ '%0.1f'|format(trh_summary.mean_temperature|float) }}°C</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Mean humidity</td>
+                    {% if not trh_summary|length == 0 %}
+                    <td>{{ '%0.1f'|format(trh_summary.mean_humidity|float) }}%</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Mean VPD</td>
+                    {% if not trh_summary|length == 0 %}
+                    <td>{{ '%0.0f'|format(trh_summary.mean_vpd|float) }} Pa</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="col-md-6 col-sm-6 col-xs-6">
+              <canvas id="temperatureCanvas"></canvas>
+              <canvas id="humidityCanvas"></canvas>
+              <canvas id="vpdCanvas"></canvas>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}
+
+{% block javascripts %}
+{{ super()}}
+
+<!-- Chart.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.8.0/chart.min.js" integrity="sha512-sW/w8s4RWTdFFSduOTGtk4isV1+190E/GghVffMA9XczdJ2MDzSzLEubKAs5h0wzgSJOQTRYyaz73L3d6RtJSg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdn.jsdelivr.net/npm/moment@^2"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@^1"></script>
+
+<script src="{{ url_for('static', filename='javascript/batch_details.js') }}"></script>
+
+<script>
+  const trh_data = JSON.parse('{{trh_json | safe}}');
+  if (trh_data.length > 0) {
+    makePlots(trh_data, "temperature", "temperatureCanvas", "Temperature", "green")
+    makePlots(trh_data, "humidity", "humidityCanvas", "Humidity", "blue")
+    makePlots(trh_data, "vpd", "vpdCanvas", "VPD", "red")
+  }
+</script>
+{% endblock javascripts %}

--- a/webapp/app/crops/templates/batch_list.html
+++ b/webapp/app/crops/templates/batch_list.html
@@ -1,0 +1,132 @@
+{% extends "base_site.html" %}
+
+{% block title %} Crop batches {% endblock title %}
+
+{% block stylesheets %}
+  {{ super() }}
+  <link href="{{ url_for('static', filename='vendors/datatables.net-bs/css/dataTables.bootstrap.min.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', filename='vendors/datatables.net-buttons-bs/css/buttons.bootstrap.min.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', filename='vendors/datatables.net-fixedheader-bs/css/fixedHeader.bootstrap.min.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', filename='vendors/datatables.net-responsive-bs/css/responsive.bootstrap.min.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', filename='vendors/datatables.net-scroller-bs/css/scroller.bootstrap.min.css') }}" rel="stylesheet">
+{% endblock stylesheets %}
+
+{% block content %}
+  <div class="right_col" role="main">
+    <div class="">
+
+      <div class="row">
+        <div class="col-md-12 col-sm-12 col-xs-12">
+          <div class="x_panel">
+
+            <div class="x_content">
+
+                <div class="row x_title">
+                    <div class="col-md-6">
+                        <h3>Crop batches</h3>
+                    </div>
+
+                    <div class="col-md-6">
+                        <div id="reportrange" class="pull-right" style="background: #fff; cursor: pointer; padding: 5px 10px; border: 1px solid #ccc">
+                            <i class="glyphicon glyphicon-calendar fa fa-calendar"></i>
+                            <span></span>
+                            <b class="caret"></b>
+                        </div>
+                    </div>
+                </div>
+
+              <table id="datatable-responsive" class="table table-striped table-bordered dt-responsive nowrap" cellspacing="0" width="100%">
+                <thead>
+                  <tr>
+                  <th>Batch id</th>
+                  <th>Last event</th>
+                  <th>Crop type</th>
+                  <th>Tray size</th>
+                  <th>Number of trays</th>
+                  <th>Weigh time</th>
+                  <th>Propagate time</th>
+                  <th>Transfer time</th>
+                  <th>Harvest time</th>
+                  <th>Location</th>
+                  <th>Yield</th>
+                  <th>Disease</th>
+                  <th>Defect</th>
+                  <th>Over-production</th>
+                  </tr>
+                </thead>
+                <tbody>
+
+                {%
+                    for batch in batches:
+                %}
+                <tr>
+                  <td>{{ batch.batch_id }}</td>
+                  <td>{{ batch.last_event }}</td>
+                  <td>{{ batch.crop_type_name }}</td>
+                  <td>{{ batch.tray_size }}</td>
+                  <td>{{ batch.number_of_trays }}</td>
+                  <td>{{ batch.weigh_time }}</td>
+                  <td>{{ batch.propagate_time }}</td>
+                  <td>{{ batch.transfer_time }}</td>
+                  <td>{{ batch.harvest_time }}</td>
+                  <td>{{ batch.zone }} - {{ batch.aisle }} - {{ batch.shelf }}</td>
+                  <td>{{ batch.crop_yield }}</td>
+                  <td>{{ batch.waste_disease }}</td>
+                  <td>{{ batch.waste_defect }}</td>
+                  <td>{{ batch.over_production }}</td>
+                </tr>
+                {%
+                    endfor
+                %}
+
+                </tbody>
+              </table>
+	      <form method="post">
+		<input type="submit" value="Download" name="download"/>
+	      </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}
+
+{% block javascripts %}
+  {{ super() }}
+  <!-- Datatables -->
+  <script src="{{ url_for('static', filename='vendors/datatables.net/js/jquery.dataTables.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-bs/js/dataTables.bootstrap.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-buttons/js/dataTables.buttons.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-buttons-bs/js/buttons.bootstrap.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-buttons/js/buttons.flash.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-buttons/js/buttons.html5.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-buttons/js/buttons.print.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-fixedheader/js/dataTables.fixedHeader.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-keytable/js/dataTables.keyTable.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-responsive/js/dataTables.responsive.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-responsive-bs/js/responsive.bootstrap.js') }}"></script>
+  <script src="{{ url_for('static', filename='vendors/datatables.net-scroller/js/dataTables.scroller.min.js') }}"></script>
+
+  <script>
+
+    $(document).ready(function() {
+        $('#datatable-responsive').DataTable( {
+            "order": [[ 0, "desc" ]]
+        } );
+    } );
+
+    $(window).load(function() {
+
+        $('#reportrange span').html("{{ dt_from }}" + ' - ' + "{{ dt_to }}");
+
+    });
+
+    $('#reportrange').on('apply.daterangepicker', function(ev, picker) {
+        var request_url = "/readings/aranet_trh?range=" + picker.startDate.format('YYYYMMDD') + "-" + picker.endDate.format('YYYYMMDD')
+
+        location.replace(request_url)
+    });
+
+</script>
+{% endblock javascripts %}

--- a/webapp/app/crops/templates/batch_list.html
+++ b/webapp/app/crops/templates/batch_list.html
@@ -123,7 +123,7 @@
     });
 
     $('#reportrange').on('apply.daterangepicker', function(ev, picker) {
-        var request_url = "/readings/aranet_trh?range=" + picker.startDate.format('YYYYMMDD') + "-" + picker.endDate.format('YYYYMMDD')
+        var request_url = "/crops/batch_list?range=" + picker.startDate.format('YYYYMMDD') + "-" + picker.endDate.format('YYYYMMDD')
 
         location.replace(request_url)
     });

--- a/webapp/app/crops/templates/batch_list.html
+++ b/webapp/app/crops/templates/batch_list.html
@@ -1,6 +1,6 @@
 {% extends "base_site.html" %}
 
-{% block title %} Crop batches {% endblock title %}
+{% block title %} CROP BATCHES {% endblock title %}
 
 {% block stylesheets %}
   {{ super() }}
@@ -42,7 +42,7 @@
                   <th>Last event</th>
                   <th>Crop type</th>
                   <th>Tray size</th>
-                  <th>Number of trays</th>
+                  <th>Trays</th>
                   <th>Weigh time</th>
                   <th>Propagate time</th>
                   <th>Transfer time</th>
@@ -52,6 +52,7 @@
                   <th>Disease</th>
                   <th>Defect</th>
                   <th>Over-production</th>
+                  <th>Details</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -74,7 +75,9 @@
                   <td>{{ batch.waste_disease }}</td>
                   <td>{{ batch.waste_defect }}</td>
                   <td>{{ batch.over_production }}</td>
-                </tr>
+                  <td class="last">
+                    <a href="/crops/batch_details?query={{ batch.batch_id }}">View</a>
+                  </td>
                 {%
                     endfor
                 %}

--- a/webapp/app/crops/templates/batch_list.html
+++ b/webapp/app/crops/templates/batch_list.html
@@ -38,6 +38,7 @@
               <table id="datatable-responsive" class="table table-striped table-bordered dt-responsive nowrap" cellspacing="0" width="100%">
                 <thead>
                   <tr>
+                  <th>Details</th>
                   <th>Batch id</th>
                   <th>Last event</th>
                   <th>Crop type</th>
@@ -52,7 +53,6 @@
                   <th>Disease</th>
                   <th>Defect</th>
                   <th>Over-production</th>
-                  <th>Details</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -61,6 +61,9 @@
                     for batch in batches:
                 %}
                 <tr>
+                  <td>
+                    <a class="dark" style="font-weight: 500;" href="/crops/batch_details?query={{ batch.batch_id }}">View</a>
+                  </td>
                   <td>{{ batch.batch_id }}</td>
                   <td>{{ batch.last_event }}</td>
                   <td>{{ batch.crop_type_name }}</td>
@@ -74,10 +77,7 @@
                   <td>{{ batch.crop_yield }}</td>
                   <td>{{ batch.waste_disease }}</td>
                   <td>{{ batch.waste_defect }}</td>
-                  <td>{{ batch.over_production }}</td>
-                  <td class="last">
-                    <a href="/crops/batch_details?query={{ batch.batch_id }}">View</a>
-                  </td>
+                  <td class="last">{{ batch.over_production }}</td>
                 {%
                     endfor
                 %}

--- a/webapp/app/crops/templates/batch_list.html
+++ b/webapp/app/crops/templates/batch_list.html
@@ -70,7 +70,7 @@
                   <td>{{ batch.propagate_time }}</td>
                   <td>{{ batch.transfer_time }}</td>
                   <td>{{ batch.harvest_time }}</td>
-                  <td>{{ batch.zone }} - {{ batch.aisle }} - {{ batch.shelf }}</td>
+                  <td>{{ batch.location }}</td>
                   <td>{{ batch.crop_yield }}</td>
                   <td>{{ batch.waste_disease }}</td>
                   <td>{{ batch.waste_defect }}</td>


### PR DESCRIPTION
The first version of displaying crop data on the front end.

There's a new section in the sidebar, called Crops. It has a page that lists all batches with some data about them, that looks like this:
![image](https://user-images.githubusercontent.com/5229876/192827765-bd6ae7de-b709-43e4-8a28-f9187730d409.png)

You can also click the "View details" button on any of them, and be presented with a page with more detailed information about that batch, along with sensor data from the nearest T&RH sensor from the growth period, like this:
![image](https://user-images.githubusercontent.com/5229876/192827952-c0946860-01c8-40c5-8315-d6bc50c99d7a.png)

Proposals for how to change are welcome, this is just my first shot at what might be useful. May e.g. want to trim the number of columns in the list table, but not sure which ones to leave out.

One new feature I would like to add but haven't done yet, is adding to the details page a comparison of the various numbers like yield and grow time to the average value for the same crop type (see https://github.com/alan-turing-institute/CROP/issues/284). Have to think about how to do that without having to query the whole batch history at every page load.

This PR also changes some of the navigation icons in the sidebar, and reorders the entries in the sidebar.