### PR TITLE
Batch details improvements

### DIFF
--- a/webapp/app/base/static/javascript/batch_details.js
+++ b/webapp/app/base/static/javascript/batch_details.js
@@ -29,7 +29,7 @@ const plotConfigTemplate = {
   },
 };
 
-function makePlots(data, yDataName, canvasName, yLabel, colour) {
+function makePlots(data, yDataName, canvasId, yLabel, colour, placeholderId) {
   const datasets = [];
   const pointRadius = 1;
   const borderWidth = 1;
@@ -45,6 +45,9 @@ function makePlots(data, yDataName, canvasName, yLabel, colour) {
   const config = JSON.parse(JSON.stringify(plotConfigTemplate)); // Make a copy
   config.options.scales.y.title.text = yLabel;
   config.data = { datasets: datasets };
-  const ctx = document.getElementById(canvasName);
+  const ctx = document.getElementById(canvasId);
   new Chart(ctx, config);
+
+  const placeholder = document.getElementById(placeholderId);
+  placeholder.style.display = "none";
 }

--- a/webapp/app/crops/routes.py
+++ b/webapp/app/crops/routes.py
@@ -1,6 +1,7 @@
 """
 Module for sensor data.
 """
+from datetime import datetime
 from flask import render_template, request
 from flask_login import login_required
 import numpy as np
@@ -345,7 +346,13 @@ def batch_details():
         details["yield_per_tray"] = None
 
     dt_from = details["transfer_time"]
-    dt_to = details["harvest_time"]
+    dt_to = (
+        details["harvest_time"]
+        if details["last_event"] == "harvest"
+        else datetime.utcnow()
+        if details["last_event"] == "transfer"
+        else None
+    )
     if dt_from and dt_to:
         (
             sensor_id,

--- a/webapp/app/crops/routes.py
+++ b/webapp/app/crops/routes.py
@@ -295,6 +295,110 @@ def query_trh_data(sensor_id, dt_from, dt_to):
     return df
 
 
+def query_propagation_trh_data(dt_from, dt_to):
+    query = (
+        db.session.query(
+            ReadingsAranetTRHClass.timestamp,
+            ReadingsAranetTRHClass.sensor_id,
+            ReadingsAranetTRHClass.temperature,
+            ReadingsAranetTRHClass.humidity,
+            SensorClass.id,
+            SensorLocationClass.sensor_id,
+            SensorLocationClass.location_id,
+            SensorLocationClass.installation_date,
+            LocationClass.zone,
+        )
+        .filter(
+            and_(
+                ReadingsAranetTRHClass.sensor_id == SensorClass.id,
+                ReadingsAranetTRHClass.timestamp >= dt_from,
+                ReadingsAranetTRHClass.timestamp <= dt_to,
+            )
+        )
+        .join(
+            SensorLocationClass,
+            SensorClass.id == SensorLocationClass.sensor_id,
+            isouter=True,
+        )
+        .join(
+            LocationClass,
+            LocationClass.id == SensorLocationClass.location_id,
+            isouter=True,
+        )
+        .filter(filter_latest_sensor_location(db))
+        .filter(LocationClass.zone == "Propagation")
+    )
+
+    df = pd.read_sql(query.statement, query.session.bind)
+    df.loc[:, "vpd"] = vapour_pressure_deficit(
+        df.loc[:, "temperature"], df.loc[:, "humidity"]
+    )
+    return df
+
+
+def batch_details_trh(details):
+    """Get data from the nearest T&RH sensor, for the relevant time period."""
+    dt_from = details["transfer_time"]
+    dt_to = (
+        details["harvest_time"]
+        if details["last_event"] == "harvest"
+        else datetime.utcnow()
+        if details["last_event"] == "transfer"
+        else None
+    )
+    if dt_from and dt_to:
+        (
+            sensor_id,
+            sensor_name,
+            sensor_zone,
+            sensor_aisle,
+            sensor_column,
+            sensor_shelf,
+        ) = find_closest_trh_sensor(
+            details["zone"], details["aisle"], details["column"], details["shelf"]
+        )
+        trh_df = query_trh_data(sensor_id, dt_from, dt_to)
+        trh_json = trh_df.to_json(orient="records")
+        trh_summary = {
+            "sensor_id": sensor_id,
+            "sensor_name": sensor_name,
+            "sensor_zone": sensor_zone,
+            "sensor_aisle": sensor_aisle,
+            "sensor_column": sensor_column,
+            "sensor_shelf": sensor_shelf,
+            "sensor_location": f"{sensor_zone} {sensor_column}{sensor_aisle}{sensor_shelf}",
+            "mean_temperature": np.mean(trh_df.loc[:, "temperature"]),
+            "mean_humidity": np.mean(trh_df.loc[:, "humidity"]),
+            "mean_vpd": np.mean(trh_df.loc[:, "vpd"]),
+        }
+    else:
+        trh_json = "{}"
+        trh_summary = {}
+    return trh_json, trh_summary
+
+
+def batch_details_prop_trh(details):
+    """Get data from the propagation T&RH sensors for the propagation time period."""
+    prop_dt_from = details["propagate_time"]
+    prop_dt_to = (
+        details["transfer_time"]
+        if details["last_event"] in ("transfer", "harvest")
+        else datetime.utcnow()
+        if details["last_event"] == "propagate"
+        else None
+    )
+    if prop_dt_from and prop_dt_to:
+        prop_trh_df = query_propagation_trh_data(prop_dt_from, prop_dt_to)
+        prop_trh_summary = {
+            "mean_temperature": np.mean(prop_trh_df.loc[:, "temperature"]),
+            "mean_humidity": np.mean(prop_trh_df.loc[:, "humidity"]),
+            "mean_vpd": np.mean(prop_trh_df.loc[:, "vpd"]),
+        }
+    else:
+        prop_trh_summary = {}
+    return prop_trh_summary
+
+
 @blueprint.route("/batch_details", methods=["GET"])
 @login_required
 def batch_details():
@@ -345,42 +449,9 @@ def batch_details():
     else:
         details["yield_per_tray"] = None
 
-    dt_from = details["transfer_time"]
-    dt_to = (
-        details["harvest_time"]
-        if details["last_event"] == "harvest"
-        else datetime.utcnow()
-        if details["last_event"] == "transfer"
-        else None
-    )
-    if dt_from and dt_to:
-        (
-            sensor_id,
-            sensor_name,
-            sensor_zone,
-            sensor_aisle,
-            sensor_column,
-            sensor_shelf,
-        ) = find_closest_trh_sensor(
-            details["zone"], details["aisle"], details["column"], details["shelf"]
-        )
-        trh_df = query_trh_data(sensor_id, dt_from, dt_to)
-        trh_json = trh_df.to_json(orient="records")
-        trh_summary = {
-            "sensor_id": sensor_id,
-            "sensor_name": sensor_name,
-            "sensor_zone": sensor_zone,
-            "sensor_aisle": sensor_aisle,
-            "sensor_column": sensor_column,
-            "sensor_shelf": sensor_shelf,
-            "sensor_location": f"{sensor_zone} {sensor_column}{sensor_aisle}{sensor_shelf}",
-            "mean_temperature": np.mean(trh_df.loc[:, "temperature"]),
-            "mean_humidity": np.mean(trh_df.loc[:, "humidity"]),
-            "mean_vpd": np.mean(trh_df.loc[:, "vpd"]),
-        }
-    else:
-        trh_json = "{}"
-        trh_summary = {}
+    # Get T&RH sensor data relevant for this batch.
+    trh_json, trh_summary = batch_details_trh(details)
+    prop_trh_summary = batch_details_prop_trh(details)
 
     # Format the time strings. Easier to do here than in the Jinja template.
     for column in ["weigh_time", "propagate_time", "transfer_time", "harvest_time"]:
@@ -394,4 +465,5 @@ def batch_details():
         details=details,
         trh_json=trh_json,
         trh_summary=trh_summary,
+        prop_trh_summary=prop_trh_summary,
     )

--- a/webapp/app/crops/templates/batch_details.html
+++ b/webapp/app/crops/templates/batch_details.html
@@ -1,5 +1,18 @@
 {% extends "base_site.html" %}
 
+{% block head %}
+{{ super() }}
+<style>
+.conditionPlotPlaceholder {
+  border: 1px solid;
+  padding: 40px;
+  margin: 30px;
+  text-align: center;
+  font-size: 1.2em;
+}
+</style>
+{% endblock head %}
+
 {% block title %} CROP BATCH DETAILS {% endblock title %}
 
 {% block content %}
@@ -123,6 +136,15 @@
             </div>
 
             <div class="col-md-6 col-sm-6 col-xs-6">
+              <div id="temperaturePlotPlaceholder" class="conditionPlotPlaceholder">
+                Temperature plot will be displayed once the batch is transferred.
+              </div>
+              <div id="humidityPlotPlaceholder" class="conditionPlotPlaceholder">
+                Humidity plot will be displayed once the batch is transferred.
+              </div>
+              <div id="vpdPlotPlaceholder" class="conditionPlotPlaceholder">
+                VPD plot will be displayed once the batch is transferred.
+              </div>
               <canvas id="temperatureCanvas"></canvas>
               <canvas id="humidityCanvas"></canvas>
               <canvas id="vpdCanvas"></canvas>
@@ -149,9 +171,30 @@
 <script>
   const trh_data = JSON.parse('{{trh_json | safe}}');
   if (trh_data.length > 0) {
-    makePlots(trh_data, "temperature", "temperatureCanvas", "Temperature", "green")
-    makePlots(trh_data, "humidity", "humidityCanvas", "Humidity", "blue")
-    makePlots(trh_data, "vpd", "vpdCanvas", "VPD", "red")
+    makePlots(
+      trh_data,
+      "temperature",
+      "temperatureCanvas",
+      "Temperature",
+      "green",
+      "temperaturePlotPlaceholder",
+    )
+    makePlots(
+      trh_data,
+      "humidity",
+      "humidityCanvas",
+      "Humidity",
+      "blue",
+      "humidityPlotPlaceholder",
+    )
+    makePlots(
+      trh_data,
+      "vpd",
+      "vpdCanvas",
+      "VPD",
+      "red",
+      "vpdPlotPlaceholder",
+    )
   }
 </script>
 {% endblock javascripts %}

--- a/webapp/app/crops/templates/batch_details.html
+++ b/webapp/app/crops/templates/batch_details.html
@@ -92,7 +92,31 @@
                     <td>{{ details.over_production }}</td>
                   </tr>
                   <tr>
-                    <td class="text-alignright">Closest sensor</td>
+                    <td class="text-alignright">Mean propagation temperature</td>
+                    {% if not prop_trh_summary|length == 0 %}
+                    <td>{{ '%0.1f'|format(prop_trh_summary.mean_temperature|float) }}°C</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Mean propagation humidity</td>
+                    {% if not prop_trh_summary|length == 0 %}
+                    <td>{{ '%0.1f'|format(prop_trh_summary.mean_humidity|float) }}%</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Mean propagation VPD</td>
+                    {% if not prop_trh_summary|length == 0 %}
+                    <td>{{ '%0.0f'|format(prop_trh_summary.mean_vpd|float) }} Pa</td>
+                    {% else %}
+                    <td>N/A</td>
+                    {% endif %}
+                  </tr>
+                  <tr>
+                    <td class="text-alignright">Closest farm sensor</td>
                     {% if not trh_summary|length == 0 %}
                     <td>{{ trh_summary.sensor_name }}</td>
                     {% else %}
@@ -108,7 +132,7 @@
                     {% endif %}
                   </tr>
                   <tr>
-                    <td class="text-alignright">Mean temperature</td>
+                    <td class="text-alignright">Mean farm temperature</td>
                     {% if not trh_summary|length == 0 %}
                     <td>{{ '%0.1f'|format(trh_summary.mean_temperature|float) }}°C</td>
                     {% else %}
@@ -116,7 +140,7 @@
                     {% endif %}
                   </tr>
                   <tr>
-                    <td class="text-alignright">Mean humidity</td>
+                    <td class="text-alignright">Mean farm humidity</td>
                     {% if not trh_summary|length == 0 %}
                     <td>{{ '%0.1f'|format(trh_summary.mean_humidity|float) }}%</td>
                     {% else %}
@@ -124,7 +148,7 @@
                     {% endif %}
                   </tr>
                   <tr>
-                    <td class="text-alignright">Mean VPD</td>
+                    <td class="text-alignright">Mean farm VPD</td>
                     {% if not trh_summary|length == 0 %}
                     <td>{{ '%0.0f'|format(trh_summary.mean_vpd|float) }} Pa</td>
                     {% else %}

--- a/webapp/app/crops/templates/batch_details.html
+++ b/webapp/app/crops/templates/batch_details.html
@@ -10,6 +10,13 @@
   text-align: center;
   font-size: 1.2em;
 }
+
+.conditionPlotCanvas {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  text-align: center;
+  font-size: 1.2em;
+}
 </style>
 {% endblock head %}
 
@@ -160,6 +167,15 @@
             </div>
 
             <div class="col-md-6 col-sm-6 col-xs-6">
+              <form method="post">
+                <input
+                    id="downloadTRHDataButton"
+                    style="margin-top: 5px; display: none"
+                    type="submit"
+                    value="Download T&RH data"
+                    name="download"
+                    />
+              </form>
               <div id="temperaturePlotPlaceholder" class="conditionPlotPlaceholder">
                 Temperature plot will be displayed once the batch is transferred.
               </div>
@@ -169,9 +185,9 @@
               <div id="vpdPlotPlaceholder" class="conditionPlotPlaceholder">
                 VPD plot will be displayed once the batch is transferred.
               </div>
-              <canvas id="temperatureCanvas"></canvas>
-              <canvas id="humidityCanvas"></canvas>
-              <canvas id="vpdCanvas"></canvas>
+              <canvas id="temperatureCanvas" class="conditionPlotCanvas"></canvas>
+              <canvas id="humidityCanvas" class="conditionPlotCanvas"></canvas>
+              <canvas id="vpdCanvas" class="conditionPlotCanvas"></canvas>
             </div>
 
           </div>
@@ -219,6 +235,8 @@
       "red",
       "vpdPlotPlaceholder",
     )
+    const downloadButton = document.getElementById("downloadTRHDataButton");
+    downloadButton.style.display = "block";
   }
 </script>
 {% endblock javascripts %}

--- a/webapp/app/crops/templates/batch_details.html
+++ b/webapp/app/crops/templates/batch_details.html
@@ -76,8 +76,8 @@
                     <td>{{ details.crop_yield }}</td>
                   </tr>
                   <tr>
-                    <td class="text-alignright">Yield per tray</td>
-                    <td>{{ details.yield_per_tray }}</td>
+                    <td class="text-alignright">Yield per square metre</td>
+                    <td>{{ details.yield_per_sqm }}</td>
                   </tr>
                   <tr>
                     <td class="text-alignright">Disease</td>

--- a/webapp/app/crops/templates/batch_list.html
+++ b/webapp/app/crops/templates/batch_list.html
@@ -39,20 +39,13 @@
                 <thead>
                   <tr>
                   <th>Details</th>
-                  <th>Batch id</th>
-                  <th>Last event</th>
                   <th>Crop type</th>
-                  <th>Tray size</th>
-                  <th>Trays</th>
+                  <th>Last event</th>
                   <th>Weigh time</th>
                   <th>Propagate time</th>
                   <th>Transfer time</th>
                   <th>Harvest time</th>
                   <th>Location</th>
-                  <th>Yield</th>
-                  <th>Disease</th>
-                  <th>Defect</th>
-                  <th>Over-production</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -62,22 +55,17 @@
                 %}
                 <tr>
                   <td>
-                    <a class="dark" style="font-weight: 500;" href="/crops/batch_details?query={{ batch.batch_id }}">View</a>
+                   <a href="/crops/batch_details?query={{ batch.batch_id }}">
+                     <i class="fa fa-info-circle"></i>
+                   </a>
                   </td>
-                  <td>{{ batch.batch_id }}</td>
-                  <td>{{ batch.last_event }}</td>
                   <td>{{ batch.crop_type_name }}</td>
-                  <td>{{ batch.tray_size }}</td>
-                  <td>{{ batch.number_of_trays }}</td>
+                  <td>{{ batch.last_event }}</td>
                   <td>{{ batch.weigh_time }}</td>
                   <td>{{ batch.propagate_time }}</td>
                   <td>{{ batch.transfer_time }}</td>
                   <td>{{ batch.harvest_time }}</td>
-                  <td>{{ batch.location }}</td>
-                  <td>{{ batch.crop_yield }}</td>
-                  <td>{{ batch.waste_disease }}</td>
-                  <td>{{ batch.waste_defect }}</td>
-                  <td class="last">{{ batch.over_production }}</td>
+                  <td class="last">{{ batch.location }}</td>
                 {%
                     endfor
                 %}

--- a/webapp/app/dashboards/routes.py
+++ b/webapp/app/dashboards/routes.py
@@ -880,6 +880,7 @@ def timeseries_dashboard():
 
     df = fetch_sensor_data(dt_from, dt_to, sensor_type, sensor_ids)
     if request.method == "POST":
+        df = df.sort_values("timestamp")
         return download_csv(df, "timeseries")
 
     data_keys = list(sensor_ids)

--- a/webapp/app/readings/templates/aranet_air_velocity.html
+++ b/webapp/app/readings/templates/aranet_air_velocity.html
@@ -65,9 +65,9 @@
 
                 </tbody>
               </table>
-	      <form method="post">
-		<input type="submit" value="Download" name="download"/>
-	      </form>
+              <form method="post">
+                <input type="submit" value="Download" name="download"/>
+              </form>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Various improvements to batch_list and batch_details:
* Remove unnecessary columns
* Show the T&RH plots in batch_details already before harvest
* Add placeholders for said plots when they are not made, i.e. before the batch is transferred to the main farm
* Add mean T&RH information for the propagation period to batch_details
* Report yield per square metre rather than yield per tray
* Add a button to download the data of the T&RH plots in batch_details
* Also, unrelatedly, sort downloaded data in the timeseries dashboard by timestamp, as requested by Zack.

Closes https://github.com/alan-turing-institute/CROP/issues/345, https://github.com/alan-turing-institute/CROP/issues/332, https://github.com/alan-turing-institute/CROP/issues/347, https://github.com/alan-turing-institute/CROP/issues/346, https://github.com/alan-turing-institute/CROP/issues/341