### PR TITLE
Fix config read

### DIFF
--- a/models/ges/ges/config.py
+++ b/models/ges/ges/config.py
@@ -1,5 +1,6 @@
 """
-Python module to read the parameters required to connect to the PostgreSQL database server
+Python module to read the parameters specified in the configuration file,
+including parameters required to connect to the PostgreSQL database server
 """
 
 from configparser import ConfigParser
@@ -34,16 +35,18 @@ def config(
             conf_dict[key] = os.environ[env_var]
 
     # special treatment for SQL environment variables
-    env_var1 = "CROP_SQL_HOST"
-    env_var2 = "CROP_SQL_USERNAME"
-    if env_var1 in os.environ:
-        conf_dict["host"] = os.environ[env_var1]
-        if env_var2 in os.environ:
-            conf_dict["user"] = os.environ[env_var2] + "@" + os.environ[env_var1]
-    env_var = "CROP_SQL_PASS"
-    if env_var in os.environ:
-        conf_dict["password"] = os.environ[env_var]
-    env_var = "CROP_SQL_DBNAME"
-    if env_var in os.environ:
-        conf_dict["dbname"] = os.environ[env_var]
+    if section == "postgresql":
+        env_var1 = "CROP_SQL_HOST"
+        env_var2 = "CROP_SQL_USERNAME"
+        if env_var1 in os.environ:
+            conf_dict["host"] = os.environ[env_var1]
+            if env_var2 in os.environ:
+                conf_dict["user"] = os.environ[env_var2] + "@" + os.environ[env_var1]
+        env_var = "CROP_SQL_PASS"
+        if env_var in os.environ:
+            conf_dict["password"] = os.environ[env_var]
+        env_var = "CROP_SQL_DBNAME"
+        if env_var in os.environ:
+            conf_dict["dbname"] = os.environ[env_var]
+
     return conf_dict

--- a/models/ges/ges/config.py
+++ b/models/ges/ges/config.py
@@ -11,6 +11,10 @@ def config(
     filename="./config.ini",
     section="postgresql",
 ):
+    # check that configuration file exists
+    if not os.path.isfile(filename):
+        raise Exception(f"File {filename} does not exist")
+
     # create a parser
     parser = ConfigParser()
     # read config file


### PR DESCRIPTION
I noticed a small bug in `config.py` of the GES model, where SQL login parameters would be returned even when a different section of the  `config.ini` file was requested. It wasn't causing any problems, but I fixed this just for consistency.