### PR TITLE
Add default_user to the web app

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -255,3 +255,11 @@ ERR_IMPORT_ERROR_2 = "Cannot convert data into a data structure (invalid values)
 ERR_IMPORT_ERROR_3 = "Data contains empty entries"
 ERR_IMPORT_ERROR_4 = "Data contains duplicates"
 ERR_IMPORT_ERROR_5 = "Data contains invalid values"
+
+DEFAULT_USER_USERNAME = "default_user"
+DEFAULT_USER_EMAIL = "N/A"
+DEFAULT_USER_PASS = (
+    os.environ["CROP_DEFAULT_USER_PASS"]
+    if "CROP_DEFAULT_USER_PASS" in os.environ
+    else None
+)

--- a/core/structure.py
+++ b/core/structure.py
@@ -528,9 +528,13 @@ class UserClass(BASE, UserMixin):
             if hasattr(value, "__iter__") and not isinstance(value, str):
                 # the ,= unpack of a singleton fails PEP8 (travis flake8 test)
                 value = value[0]
-            if prop == "password":
-                value = hashpw(value.encode("utf8"), gensalt())
             setattr(self, prop, value)
+
+    def __setattr__(self, prop, value):
+        """Like setattr, but if the property we are setting is the password, hash it."""
+        if prop == "password":
+            value = hashpw(value.encode("utf8"), gensalt())
+        super().__setattr__(prop, value)
 
     def __repr__(self):
         """

--- a/core/utils.py
+++ b/core/utils.py
@@ -272,3 +272,40 @@ def create_user(username, email, password):
     except exc.SQLAlchemyError as e:
         db.session.rollback()
         return False, str(e)
+
+
+def delete_user(username, email):
+    """Delete the user with this username and email.
+
+    Return (True, user_id) if successful, (False, error_message) if not.
+    """
+    try:
+        user = UserClass.query.filter_by(username=username, email=email).first()
+        db.session.delete(user)
+        db.session.flush()
+        db.session.commit()
+        return True, user.id
+    except exc.SQLAlchemyError as e:
+        db.session.rollback()
+        return False, str(e)
+
+
+def change_user_password(username, email, password):
+    """Change the password of a given user.
+
+    Return (True, user_id) if successful, (False, error_message) if not.
+    """
+    try:
+        user = UserClass.query.filter_by(username=username, email=email).first()
+        old_hashed_password = user.password
+        user.password = password
+        new_hashed_password = user.password
+        if old_hashed_password != new_hashed_password:
+            db.session.flush()
+            db.session.commit()
+            return True, user.id
+        else:
+            return False, f"Password already up-to-date for {username}"
+    except exc.SQLAlchemyError as e:
+        db.session.rollback()
+        return False, str(e)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+from bcrypt import gensalt, hashpw
+import pytest
+
+from .conftest import check_for_docker
+from core.db import session_close
+from core.structure import UserClass
+from core import utils
+
+DOCKER_RUNNING = check_for_docker()
+
+
+def _get_password_hash(username, email):
+    """Return the password hash for the given user, or None if the user doesn't exist."""
+    query = UserClass.query.filter_by(username=username, email=email)
+    if query.count() > 0:
+        return query.first().password
+    else:
+        return None
+
+
+def _user_exists(username, email):
+    """Return a bool for whether the given user credentials exist in the database."""
+    return _get_password_hash(username, email) is not None
+
+
+@pytest.mark.skipif(not DOCKER_RUNNING, reason="requires docker")
+def test_user_create_modify_delete(app):
+    """Test creating a user, changing their password, and deleting them."""
+    username = "vebaonstotunawoutnvscvinkowuyfsyaeovuakvsrka"
+    email = "tanosrvoasntekvfwluthva`onqtoywucuyauonvozkssenatenoa"
+    password1 = "tnoasriecvnulw`thfoyauncu ncxiekstovnauonfwocua"
+    password2 = "v akvfztazrfitlula`tuqlfnpav`foluhkmionulh"
+
+    with app.app_context():
+        assert not _user_exists(username, email)
+        utils.create_user(username, email, password1)
+        assert _user_exists(username, email)
+
+        old_hash = (
+            UserClass.query.filter_by(username=username, email=email).first().password
+        )
+        utils.change_user_password(username, email, password2)
+        assert _user_exists(username, email)
+        new_hash = (
+            UserClass.query.filter_by(username=username, email=email).first().password
+        )
+        assert old_hash != new_hash
+
+        utils.delete_user(username, email)
+        assert not _user_exists(username, email)

--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -9,7 +9,7 @@ from os import path
 from core.constants import DEFAULT_USER_USERNAME, DEFAULT_USER_EMAIL, DEFAULT_USER_PASS
 from core.structure import SQLA as db
 from core.structure import UserClass
-from core.utils import change_user_password, create_user
+from core.utils import change_user_password, create_user, delete_user
 
 login_manager = LoginManager()
 
@@ -110,14 +110,16 @@ def apply_themes(app):
 
 
 def add_default_user(app):
-    """Add a default user with a given password."""
-    if DEFAULT_USER_PASS is not None:
-        user_info = {
-            "username": DEFAULT_USER_USERNAME,
-            "email": DEFAULT_USER_EMAIL,
-            "password": DEFAULT_USER_PASS,
-        }
-        with app.app_context():
+    """Ensure that there's a default user from CROP, with the right credentials."""
+    with app.app_context():
+        if DEFAULT_USER_PASS is None:
+            delete_user(username=DEFAULT_USER_USERNAME, email=DEFAULT_USER_EMAIL)
+        else:
+            user_info = {
+                "username": DEFAULT_USER_USERNAME,
+                "email": DEFAULT_USER_EMAIL,
+                "password": DEFAULT_USER_PASS,
+            }
             success, _ = create_user(**user_info)
             if not success:
                 # Presumably the user exists already, so change their password.

--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -6,8 +6,10 @@ from importlib import import_module
 from logging import basicConfig, DEBUG, getLogger, StreamHandler
 from os import path
 
+from core.constants import DEFAULT_USER_USERNAME, DEFAULT_USER_EMAIL, DEFAULT_USER_PASS
 from core.structure import SQLA as db
 from core.structure import UserClass
+from core.utils import change_user_password, create_user
 
 login_manager = LoginManager()
 
@@ -107,6 +109,21 @@ def apply_themes(app):
         return url_for(endpoint, **values)
 
 
+def add_default_user(app):
+    """Add a default user with a given password."""
+    if DEFAULT_USER_PASS is not None:
+        user_info = {
+            "username": DEFAULT_USER_USERNAME,
+            "email": DEFAULT_USER_EMAIL,
+            "password": DEFAULT_USER_PASS,
+        }
+        with app.app_context():
+            success, _ = create_user(**user_info)
+            if not success:
+                # Presumably the user exists already, so change their password.
+                change_user_password(**user_info)
+
+
 def create_app(config, selenium=False):
     app = Flask(__name__, static_folder="base/static")
     app.config.from_object(config)
@@ -120,4 +137,5 @@ def create_app(config, selenium=False):
     configure_logs(app)
     apply_themes(app)
     CORS(app)
+    add_default_user(app)
     return app

--- a/webapp/app/users/routes.py
+++ b/webapp/app/users/routes.py
@@ -12,6 +12,9 @@ from core import utils
 @login_required
 def users():
     if request.method == "POST":
+        # TODO This should now use utils.delete_user. The reason this is a tiny bit
+        # non-trivial is that that one takes an email and a password, this one takes an
+        # id.
         user_id = request.values.get("user_id")
         user = db.session.get(UserClass, user_id)
         db.session.delete(user)


### PR DESCRIPTION
Add a mechanism that creates a user with default credentials, the password for which can be set with an environment variable. If the envar is not set, no user is created, or if one exists already, it is deleted.

The need for this came up when creating a new database from scratch: If there's no user in the database to login as, then we can't access the feature to add a new user, and are thus permanently logged out of the platform, barring some manual database queries.

I don't think this opens up any new attack vectors (if someone has access to setting the environment variables of the runtime environment then we are pretty screwed already), but let me know if you think otherwise.